### PR TITLE
Add configurable pinouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Other pinouts can be used by passing a `pinout` parameter to the `init`
 function.
 This pinout consists of 4 numbers giving the *positive* pin in each differential pair, in the order CK, D0, D1, D2, D3, using GPIO numbering.
 The default pinout is written `{13, 15, 17, 19}`.
-Only pin numbers from 12 to 20 are valid, as other pins are not connected to the HSTX peripheral.
+Only pin numbers from 12 to 19 are valid, as other pins are not connected to the HSTX peripheral.
 Using invalid pin numbers is an undignosed error.
 
 TODO

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Wire up your DVI breakout as follows:
 
 If using jumper jerky, twist the - and + wires for each signal together to help with signal integrity.
 
+Other pinouts can be used by passing a `pinout` parameter to the `init`
+function.
+This pinout consists of 4 numbers giving the *positive* pin in each differential pair, in the order CK, D0, D1, D2, D3, using GPIO numbering.
+The default pinout is written `{13, 15, 17, 19}`.
+Only pin numbers from 12 to 20 are valid, as other pins are not connected to the HSTX peripheral.
+Using invalid pin numbers is an undignosed error.
+
 TODO
 
 ## C/C++ Resources

--- a/drivers/dvhstx/dvhstx.cpp
+++ b/drivers/dvhstx/dvhstx.cpp
@@ -910,7 +910,7 @@ bool DVHSTX::init(uint16_t width, uint16_t height, Mode mode_, Pinout pinout)
         // The two halves of each pair get identical data, but one pin is inverted.
         hstx_ctrl_hw->bit[bit    ] = lane_data_sel_bits;
         hstx_ctrl_hw->bit[bit ^ 1] = lane_data_sel_bits | HSTX_CTRL_BIT0_INV_BITS;
-}
+    }
 
     for (int i = 12; i <= 19; ++i) {
         gpio_set_function(i, GPIO_FUNC_HSTX);

--- a/drivers/dvhstx/dvhstx.cpp
+++ b/drivers/dvhstx/dvhstx.cpp
@@ -599,7 +599,7 @@ DVHSTX::DVHSTX()
     dma_claim_mask((1 << NUM_CHANS) - 1);
 }
 
-bool DVHSTX::init(uint16_t width, uint16_t height, Mode mode_)
+bool DVHSTX::init(uint16_t width, uint16_t height, Mode mode_, Pinout pinout)
 {
     if (inited) reset();
 
@@ -889,24 +889,28 @@ bool DVHSTX::init(uint16_t width, uint16_t height, Mode mode_)
         HSTX_CTRL_CSR_EN_BITS; 
 
     // HSTX outputs 0 through 7 appear on GPIO 12 through 19.
+    constexpr int HSTX_FIRST_PIN = 12;
 
     // Assign clock pair to two neighbouring pins:
-    hstx_ctrl_hw->bit[1] = HSTX_CTRL_BIT0_CLK_BITS;
-    hstx_ctrl_hw->bit[0] = HSTX_CTRL_BIT0_CLK_BITS | HSTX_CTRL_BIT0_INV_BITS;
+    {
+    int bit = pinout.clk_p - HSTX_FIRST_PIN;
+    hstx_ctrl_hw->bit[bit    ] = HSTX_CTRL_BIT0_CLK_BITS;
+    hstx_ctrl_hw->bit[bit ^ 1] = HSTX_CTRL_BIT0_CLK_BITS | HSTX_CTRL_BIT0_INV_BITS;
+    }
+
     for (uint lane = 0; lane < 3; ++lane) {
         // For each TMDS lane, assign it to the correct GPIO pair based on the
         // desired pinout:
-        static const int lane_to_output_bit[3] = {2, 4, 6};
-        int bit = lane_to_output_bit[lane];
+        int bit = pinout.rgb_p[lane] - HSTX_FIRST_PIN;
         // Output even bits during first half of each HSTX cycle, and odd bits
         // during second half. The shifter advances by two bits each cycle.
         uint32_t lane_data_sel_bits =
             (lane * 10    ) << HSTX_CTRL_BIT0_SEL_P_LSB |
             (lane * 10 + 1) << HSTX_CTRL_BIT0_SEL_N_LSB;
         // The two halves of each pair get identical data, but one pin is inverted.
-        hstx_ctrl_hw->bit[bit    ] = lane_data_sel_bits | HSTX_CTRL_BIT0_INV_BITS;
-        hstx_ctrl_hw->bit[bit + 1] = lane_data_sel_bits;
-    }
+        hstx_ctrl_hw->bit[bit    ] = lane_data_sel_bits;
+        hstx_ctrl_hw->bit[bit ^ 1] = lane_data_sel_bits | HSTX_CTRL_BIT0_INV_BITS;
+}
 
     for (int i = 12; i <= 19; ++i) {
         gpio_set_function(i, GPIO_FUNC_HSTX);

--- a/drivers/dvhstx/dvhstx.hpp
+++ b/drivers/dvhstx/dvhstx.hpp
@@ -29,6 +29,10 @@ namespace pimoroni {
   public:
     static constexpr int PALETTE_SIZE = 256;
 
+    struct Pinout {
+        uint8_t clk_p, rgb_p[3];
+    };
+
     enum Mode {
       MODE_PALETTE = 2,
       MODE_RGB565 = 1,
@@ -92,7 +96,7 @@ namespace pimoroni {
 
       void clear();
 
-      bool init(uint16_t width, uint16_t height, Mode mode = MODE_RGB565);
+      bool init(uint16_t width, uint16_t height, Mode mode = MODE_RGB565, Pinout pinout = {13, 15, 17, 19});
       void reset();
 
       // Wait for vsync and then flip the buffers


### PR DESCRIPTION
Adapted from Adafruit_dvhstx.

I tested this on a prototype Adafruit FruitJam and both before and after my changes the program wouldn't start "normally" (from power on or pressing reset) but would start with a gdb "run" command. Weird, and something to diagnose on my end.